### PR TITLE
Fix for Ruby 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
+  - 2.3.1
+  - 2.4.1
   - ruby-head
 
 bundler_args: --without development --retry=3 --jobs=3

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ OStatus2
 ==========
 
 [![Gem Version](http://img.shields.io/gem/v/ostatus2.svg)][gem]
-[![Build Status](http://img.shields.io/travis/Gargron/ostatus2.svg)][travis]
-[![Dependency Status](http://img.shields.io/gemnasium/Gargron/ostatus2.svg)][gemnasium]
+[![Build Status](http://img.shields.io/travis/tootsuite/ostatus2.svg)][travis]
+[![Dependency Status](http://img.shields.io/gemnasium/tootsuite/ostatus2.svg)][gemnasium]
 
 [gem]: https://rubygems.org/gems/ostatus2
-[travis]: https://travis-ci.org/Gargron/ostatus2
-[gemnasium]: https://gemnasium.com/Gargron/ostatus2
+[travis]: https://travis-ci.org/tootsuite/ostatus2
+[gemnasium]: https://gemnasium.com/tootsuite/ostatus2
 
 A Ruby toolset for interacting with the OStatus suite of protocols:
 

--- a/lib/ostatus2/magic_key.rb
+++ b/lib/ostatus2/magic_key.rb
@@ -5,7 +5,7 @@ module OStatus2
       modulus, exponent = [modulus, exponent].map { |n| decode_base64(n).bytes.inject(0) { |a, e| (a << 8) | e } }
 
       key = OpenSSL::PKey::RSA.new
-      key.set_key(modulus, exponent, key.d)
+      key.set_key(modulus, exponent, nil)
       key.to_pem
     end
 

--- a/lib/ostatus2/magic_key.rb
+++ b/lib/ostatus2/magic_key.rb
@@ -4,10 +4,8 @@ module OStatus2
       _, modulus, exponent = magic_key.split('.')
       modulus, exponent = [modulus, exponent].map { |n| decode_base64(n).bytes.inject(0) { |a, e| (a << 8) | e } }
 
-      key   = OpenSSL::PKey::RSA.new
-      key.n = modulus
-      key.e = exponent
-
+      key = OpenSSL::PKey::RSA.new
+      key.set_key(modulus, exponent, key.d)
       key.to_pem
     end
 

--- a/lib/ostatus2/version.rb
+++ b/lib/ostatus2/version.rb
@@ -1,3 +1,3 @@
 module OStatus2
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/ostatus2.gemspec
+++ b/ostatus2.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib LICENSE README.md`.split($RS)
   spec.require_paths = ["lib"]
 
+  spec.add_dependency('openssl', '~> 2.0')
   spec.add_dependency('http', '~> 2.0')
   spec.add_dependency('addressable', '~> 2.4')
   spec.add_dependency('nokogiri', '~> 1.6')


### PR DESCRIPTION
Looks like Ruby 2.4.1 made the `n` attribute on `OpenSSL::PKey::RSA` read-only, but rubies before that do not have a `set_key` method. I don't know how to handle this incompatibility...