### PR TITLE
Don't use key.set_key on Ruby 2.3, it is not always available on this version.

### DIFF
--- a/lib/ostatus2/magic_key.rb
+++ b/lib/ostatus2/magic_key.rb
@@ -1,11 +1,22 @@
 module OStatus2
   module MagicKey
+    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.0')
+      def set_key(key, modulus, exponent)
+        key.n = modulus
+        key.e = exponent
+      end
+    else
+      def set_key(key, modulus, exponent)
+        key.set_key(modulus, exponent, nil)
+      end
+    end
+
     def magic_key_to_pem(magic_key)
       _, modulus, exponent = magic_key.split('.')
       modulus, exponent = [modulus, exponent].map { |n| decode_base64(n).bytes.inject(0) { |a, e| (a << 8) | e } }
 
       key = OpenSSL::PKey::RSA.new
-      key.set_key(modulus, exponent, nil)
+      set_key(key, modulus, exponent)
       key.to_pem
     end
 


### PR DESCRIPTION
Compatibility with Ruby 2.3 was broken in commit 09632231b7653f47c3d176aa99bc1baf6009d396 (a fix for 2.4).

Closes https://github.com/tootsuite/mastodon/issues/2029 .