### PR TITLE
openssl 2.0 is not required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 cache: bundler
 
 rvm:
+  - 2.1
+  - 2.2
   - 2.3.1
   - 2.4.1
   - ruby-head

--- a/ostatus2.gemspec
+++ b/ostatus2.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib LICENSE README.md`.split($RS)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency('openssl', '~> 2.0')
   spec.add_dependency('http', '~> 2.0')
   spec.add_dependency('addressable', '~> 2.4')
   spec.add_dependency('nokogiri', '~> 1.6')


### PR DESCRIPTION
Remove openssl 2.0 dependency (to avoid
https://github.com/ruby/openssl/issues/180)

Test on old rubies.