### PR TITLE
Workaround Travis CI bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ rvm:
   - 2.2
   - 2.3.1
   - 2.4.1
+  - 2.5
   - ruby-head
+
+before_install: travis_retry gem update --system
 
 bundler_args: --without development --retry=3 --jobs=3
 


### PR DESCRIPTION
Rubygems 2.7.3 and Bundler 1.16.1 do not go together well. Update to Rubygems 2.7.4 early in the build.

https://github.com/travis-ci/travis-ci/issues/8969  